### PR TITLE
Stop throwing exceptions in cterm vim.

### DIFF
--- a/plugin/limelight.vim
+++ b/plugin/limelight.vim
@@ -82,7 +82,16 @@ let s:gray_converter = {
 
 function! s:gray_contiguous(col)
   let val = get(s:gray_converter, a:col, a:col)
-  if val < 231 || val > 256
+  if (val < 231 || val > 256)
+    if has('gui_running')
+      if exists('g:limelight_conceal_guifg')
+        return g:limelight_conceal_guifg
+      endif
+    else
+      if exists('g:limelight_conceal_ctermfg')
+        return g:limelight_conceal_ctermfg
+      endif
+    endif
     throw s:unsupported
   endif
   return val


### PR DESCRIPTION
@junegunn

Neat idea for a plugin!

I was getting an "Unsupported color scheme" exception even after setting the cterm environment variables. I patched it below, though I'm not sure if this was the behavior you wanted.

I didn't look into patching the tests to cover this case, but that'd probably make sense to do.
