### PR TITLE
Exclude whitespace-only lines from Limelight range

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -43,17 +43,21 @@ function! s:unsupported()
 endfunction
 
 function! s:getpos()
-  let span = max([0, get(g:, 'limelight_paragraph_span', 0) - empty(getline('.'))])
+  let span = max([0, get(g:, 'limelight_paragraph_span', 0) - s:empty(getline('.'))])
   let pos = getpos('.')
   for _ in range(0, span)
-    let start = searchpos('^$', 'bW')[0]
+    let start = searchpos('^\s*$', 'bW')[0]
   endfor
   call setpos('.', pos)
   for _ in range(0, span)
-    let end = searchpos('^$', 'W')[0]
+    let end = searchpos('^\s*$', 'W')[0]
   endfor
   call setpos('.', pos)
   return [start, end]
+endfunction
+
+function! s:empty(line)
+  return (a:line =~# '^\s*$')
 endfunction
 
 function! s:limelight()


### PR DESCRIPTION
Not sure if you'll be into this PR, but I wanted to try using Limelight while reading code instead of just README.md's (inspiration from this blog post https://zenbro.github.io/2015/06/09/meditating-on-code.html).  The codebase I work on has a lot of lines that contain just whitespace which caused Limelight to highlight the entire page in some instances because the lines weren't technically empty.

This change would allow Limelight to ignore whitespace-only lines when determining the region to highlight.  I ran the Vader tests and everything passed (except for one TODO test case about color interpolation).

Let me know what you think of it.