### PR TITLE
improve test for truecolor support

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -139,7 +139,7 @@ function! s:dim(coeff)
   let fg = synIDattr(synid, 'fg#')
   let bg = synIDattr(synid, 'bg#')
 
-  if has('gui_running') || (exists('+termguicolors') && termguicolors)|| has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
+  if has('gui_running') || exists('+termguicolors') && termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg
     elseif empty(fg) || empty(bg)

--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -139,7 +139,7 @@ function! s:dim(coeff)
   let fg = synIDattr(synid, 'fg#')
   let bg = synIDattr(synid, 'bg#')
 
-  if has('gui_running') || exists('+termguicolors') && termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
+  if has('gui_running') || has('termguicolors') && termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg
     elseif empty(fg) || empty(bg)

--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -139,7 +139,7 @@ function! s:dim(coeff)
   let fg = synIDattr(synid, 'fg#')
   let bg = synIDattr(synid, 'bg#')
 
-  if has('gui_running') || has('termguicolors') && termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
+  if has('gui_running') || has('termguicolors') && &termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg
     elseif empty(fg) || empty(bg)

--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -139,7 +139,7 @@ function! s:dim(coeff)
   let fg = synIDattr(synid, 'fg#')
   let bg = synIDattr(synid, 'bg#')
 
-  if has('gui_running') || exists('+termguicolors') || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
+  if has('gui_running') || (exists('+termguicolors') && termguicolors)|| has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg
     elseif empty(fg) || empty(bg)

--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -139,7 +139,7 @@ function! s:dim(coeff)
   let fg = synIDattr(synid, 'fg#')
   let bg = synIDattr(synid, 'bg#')
 
-  if has('gui_running') || has('termguicolors') && &termguicolors
+  if has('gui_running') || exists('+termguicolors') || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg
     elseif empty(fg) || empty(bg)


### PR DESCRIPTION
This improves limelight account for truecolor support in both vim and nvim. 

improves the treatment of the problem described by #30.

rationale:

`exists('+termguicolors')` works for both vim and nvim, if this feature is present.
nvim before version 0.1.5 also supports truecolors even without +termguicolors.
