### PR TITLE
use winsaveview instead of getpos

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -46,15 +46,15 @@ function! s:getpos()
   let bop = get(g:, 'limelight_bop', '^\s*$\n\zs')
   let eop = get(g:, 'limelight_eop', '^\s*$')
   let span = max([0, get(g:, 'limelight_paragraph_span', 0) - s:empty(getline('.'))])
-  let pos = getpos('.')
+  let win_view = winsaveview()
   for i in range(0, span)
     let start = searchpos(bop, i == 0 ? 'cbW' : 'bW')[0]
   endfor
-  call setpos('.', pos)
+  call winrestview(win_view)
   for _ in range(0, span)
     let end = searchpos(eop, 'W')[0]
   endfor
-  call setpos('.', pos)
+  call winrestview(win_view)
   return [start, end]
 endfunction
 


### PR DESCRIPTION
Consider this template:

```
foo

bar
```

If you move your cursor to the second column in the first line and then press `j` two times you would expect to end up in the second column in the third line (this behavior is controlled by `startofline`). But with limelight activated you end up in the first column.