### PR TITLE
Fix the bug #43

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -46,7 +46,7 @@ function! s:getpos()
   let bop = get(g:, 'limelight_bop', '^\s*$\n\zs')
   let eop = get(g:, 'limelight_eop', '^\s*$')
   let span = max([0, get(g:, 'limelight_paragraph_span', 0) - s:empty(getline('.'))])
-  let pos = getcurpos()
+  let pos = exists('*getcurpos')? getcurpos() : getpos('.')
   for i in range(0, span)
     let start = searchpos(bop, i == 0 ? 'cbW' : 'bW')[0]
   endfor

--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -46,7 +46,7 @@ function! s:getpos()
   let bop = get(g:, 'limelight_bop', '^\s*$\n\zs')
   let eop = get(g:, 'limelight_eop', '^\s*$')
   let span = max([0, get(g:, 'limelight_paragraph_span', 0) - s:empty(getline('.'))])
-  let pos = getpos('.')
+  let pos = getcurpos()
   for i in range(0, span)
     let start = searchpos(bop, i == 0 ? 'cbW' : 'bW')[0]
   endfor


### PR DESCRIPTION
The commit is for fixing the bug #43 "cursor does not maintain horizontal position when moving.
I use the function getcurpos instead of getpos.

getpos
> The result is a List with four numbers:
> [bufnum, lnum, col, off]

getcurpos
> The result is a List with five numbers:
> [bufnum, lnum, col, off, curswant]


The time getcurpos was added:
https://github.com/vim/vim/commit/6f6c0f8085a5b0855f9dce8378086fd5e06a219b