### PR TITLE
Don't move the cursor to beginning of line on deactivating limelight

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -254,8 +254,8 @@ function! s:cleanup()
   end
 endfunction
 
-function! limelight#execute(bang, visual, ...) range
-  let range = a:visual ? [a:firstline, a:lastline] : []
+function! limelight#execute(bang, visual, line1, line2, ...)
+  let range = a:visual ? [a:line1, a:line2] : []
   if a:bang
     if a:0 > 0 && a:1 =~ '^!' && !s:is_on()
       if len(a:1) > 1

--- a/plugin/limelight.vim
+++ b/plugin/limelight.vim
@@ -21,7 +21,7 @@
 " OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 " WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-command! -nargs=? -bar -bang -range Limelight <line1>,<line2>call limelight#execute(<bang>0, <count> > 0, <f-args>)
+command! -nargs=? -bar -bang -range Limelight call limelight#execute(<bang>0, <count> > 0, <line1>, <line2>, <f-args>)
 
 nnoremap <silent> <Plug>(Limelight) :set opfunc=limelight#operator<CR>g@
 xnoremap <silent> <Plug>(Limelight) :Limelight<CR>


### PR DESCRIPTION
I was using Limelight automatically in insert mode but not in normal
mode using the following snippet in my vimrc:

```
augroup writing
  au!

  autocmd! InsertEnter * Limelight
  autocmd! InsertLeave * Limelight!
augroup END
```

This works pretty well specifically for coding since you can still
see the syntax highlighting of the entire file while in normal mode
(which one is usually in while reading the code) but are not distracted
from all that noise while writing.
The only problem was that because of how the range was passed to the
`execute` function my cursor was moving to the beginning of the line
whenever I exited insert mode. Today I was annoyed enough of that to
do something about it :laughing:.

I made the `Limelight` command pass the range as parameters to the
`execute` function which removes that effect while `Limelight`ening
a range still works. I'm no expert in vim script so please tell me if
there is a better way to do this or if I have forgotten any edge case
and I'll fix it.