### PR TITLE
Allow limelight to work with transparent backgrounds

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -137,8 +137,8 @@ endfunction
 function! s:dim(coeff)
   let synid = synIDtrans(hlID('Normal'))
   let fg = synIDattr(synid, 'fg#')
-  let bg = synIDattr(synid, 'bg#')
-
+  let bg = 0
+  
   if has('gui_running') || has('termguicolors') && &termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg


### PR DESCRIPTION
Right now limelight throws an error about not being able to calculate bg color because of `ctermbg` value of `Normal` highlight group being set to `none` to allow transparency in terminals. Setting the `bg` value for `dim coefficient` to `0` solves this.

This isn't the most elegant solution, but it allows limelight to work in transparent terminals, and still leaves room for changing the brightness of concealed text.

In the future we could run a check to see if `ctermbg` for `Normal` is `none` and then set dim bg to 0, but I'm not that experienced with vimscript yet.