### PR TITLE
Add a check to work with transparent themes 

### DIFF
--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -137,8 +137,8 @@ endfunction
 function! s:dim(coeff)
   let synid = synIDtrans(hlID('Normal'))
   let fg = synIDattr(synid, 'fg#')
-  let bg = synIDattr(synid, 'bg#')
-
+  let bg = 0
+  
   if has('gui_running') || has('termguicolors') && &termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')
       let dim = g:limelight_conceal_guifg

--- a/autoload/limelight.vim
+++ b/autoload/limelight.vim
@@ -137,7 +137,11 @@ endfunction
 function! s:dim(coeff)
   let synid = synIDtrans(hlID('Normal'))
   let fg = synIDattr(synid, 'fg#')
-  let bg = 0
+  if synIDattr(synid, 'bg#') == 'none'
+    let bg = 0
+  else
+    let bg = synIDattr(synid, 'bg#')
+  endif
   
   if has('gui_running') || has('termguicolors') && &termguicolors || has('nvim') && $NVIM_TUI_ENABLE_TRUE_COLOR
     if a:coeff < 0 && exists('g:limelight_conceal_guifg')


### PR DESCRIPTION
This PR adds a check to see if ctermbg is set to none (used in themes with transparent backgrounds) and changes the bg value to 0 as a fix, otherwise the plugin works as before.